### PR TITLE
Prop refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@rcpch/digital-growth-charts-react-component-library": "1.1.2",
+    "@rcpch/digital-growth-charts-react-component-library": "2.0.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -10,7 +10,6 @@ function ChartData(props) {
         const [isLoading, setLoading] = useState(true)
         const [centile_data, setCentile_data] = useState([])
         // const [sds_data, setSDS_data] = useState([])
-        
 
         const measurementsArray = props.measurementsArray
         const reference = props.reference
@@ -59,19 +58,11 @@ function ChartData(props) {
                         title={titles.title}
                         subtitle={titles.subtitle}
                         measurementsArray = {centile_data} // this is the plottable child data
-                        chartBackground={props.chartBackground}
-                        gridlineStroke={props.gridlineStroke}
-                        gridlineStrokeWidth={props.gridlineStrokeWidth}
-                        gridlineDashed={props.gridlineDashed}
-                        gridlines={props.gridlines}
-                        centileStroke={props.centileStroke}
-                        centileStrokeWidth={props.centileStrokeWidth}
-                        axisStroke={props.axisStroke}
-                        axisLabelFont={props.axisLabelFont}
-                        axisLabelColour={props.axisLabelColour}
-                        measurementFill={props.measurementFill}
-                        measurementSize={props.measurementSize}
-                        measurementShape={props.measurementShape}
+                        chartStyle={props.chartStyle}
+                        axisStyle={props.axisStyle}
+                        gridlineStyle={props.gridlineStyle}
+                        centileStyle={props.centileStyle}
+                        measurementStyle={props.measurementStyle}
                     />
                     </div>
                 )

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -13,13 +13,14 @@ function ChartData(props) {
         
 
         const measurementsArray = props.measurementsArray
+        const reference = props.reference
         const titles = setTitle(props);
 
         useEffect( () => {
             let ignore = false; // this prevents data being added to state if unmounted
             if (measurementsArray.length > 0){
                 try{
-                    fetchCentileData(measurementsArray).then(result => {
+                    fetchCentileData(measurementsArray, reference).then(result => {
                         if (!ignore){ // this prevents data being added to state if unmounted
                             setCentile_data(result.data.child_data.centile_data)
                             // setSDS_data(result.data.child_data.sds_data)
@@ -41,7 +42,7 @@ function ChartData(props) {
             }
             return (() => { ignore = true; }); // this prevents data being added to state if unmounted
 
-        }, [measurementsArray])
+        }, [measurementsArray, reference])
     
         return (
           <div>
@@ -124,13 +125,13 @@ function setTitle(props){
      return {subtitle: subTitle, title: title}
 }
 
-async function fetchCentileData(measurementsArray){
+async function fetchCentileData(measurementsArray, reference){
     const formData = {
         results: measurementsArray // measurements passed in from the form
     };
     
     const response = await axios({
-          url: `${process.env.REACT_APP_GROWTH_API_BASEURL}/uk-who/plottable-child-data`,
+          url: `${process.env.REACT_APP_GROWTH_API_BASEURL}/`+ reference + `/plottable-child-data`,
           data: formData,
           method: "POST",
           headers: {

--- a/src/components/MeasurementSegment.js
+++ b/src/components/MeasurementSegment.js
@@ -4,7 +4,7 @@ import { Component } from "react";
 import RCPCHTheme1 from "../components/chartThemes/rcpchTheme1";
 import RCPCHTheme2 from "../components/chartThemes/rcpchTheme2";
 import RCPCHTheme3 from "../components/chartThemes/rcpchTheme3";
-import RCPCHMonochrome  from "./chartThemes/rcpchThemeMonochrome";
+import RCPCHThemeMonochrome from "../components/chartThemes/rcpchThemeMonochrome";
 import RCPCHThemeTraditionalBoy from '../components/chartThemes/RCPCHThemeTraditionalBoy'
 import RCPCHThemeTraditionalGirl from '../components/chartThemes/RCPCHThemeTraditionalGirl'
 
@@ -13,7 +13,6 @@ import { Grid, Segment, Message, Flag, Tab, Menu, Dropdown, Button, Table, List 
 import ChartData from '../api/Chart'
 import MeasurementForm from "../components/MeasurementForm";
 import '../index.css'
-import RCPCHThemeMonochrome from "./chartThemes/rcpchThemeMonochrome";
 
 /*
     return object structure from API
@@ -60,7 +59,7 @@ class MeasurementSegment extends Component {
         super(props)
 
         // const dummyData=[{birth_data:{birth_date:"Wed, 28 Jan 2015 00:00:00 GMT",estimated_date_delivery:null,estimated_date_delivery_string:null,gestation_days:0,gestation_weeks:40,sex:"male"},child_observation_value:{measurement_method:"height",observation_value:110},measurement_calculated_values:{centile:13,centile_band:"This height measurement is between the 9th and 25th centiles.",measurement_method:"height",sds:-1.117076305831875},measurement_dates:{chronological_calendar_age:"5 years, 10 months and 4 weeks",chronological_decimal_age:5.9110198494182065,clinician_decimal_age_comment:"Born Term. No correction necessary.",corrected_calendar_age:null,corrected_decimal_age:5.9110198494182065,corrected_gestational_age:{corrected_gestation_days:null,corrected_gestation_weeks:null},lay_decimal_age_comment:"At 40+0, your child is considered to have been born at term. No age adjustment is necessary.",observation_date:"Sat, 26 Dec 2020 00:00:00 GMT"}}]
-        const defaultTheme = RCPCHMonochrome;
+        const defaultTheme = RCPCHThemeMonochrome;
         
         this.state = {
           measurementMethod: "height",
@@ -237,31 +236,23 @@ class MeasurementSegment extends Component {
     gridlineStyle, 
     centileStyle, 
     measurementStyle){
-
-    const Chart = (
-      <ChartData
-            key={measurementMethod + "-" + this.state.reference}
-            reference={this.state.reference} //the choices are ["uk-who", "turner", "trisomy-21"] REQUIRED
-            sex={this.state.sex} //the choices are ["male", "female"] REQUIRED
-            measurementMethod={measurementMethod} //the choices are ["height", "weight", "ofc", "bmi"] REQUIRED
-            measurementsArray = {measurementsArray}  // an array of Measurement class objects from dGC Optional
-            // measurementsSDSArray = {[]} // an array of SDS measurements for SDS charts Optional: currently not implemented: pass []
-            chartBackground={chartStyle.backgroundColour}
-            gridlineStroke={gridlineStyle.stroke}
-            gridlineStrokeWidth={gridlineStyle.strokeWidth}
-            gridlineDashed={gridlineStyle.dashed}
-            gridlines={gridlineStyle.gridlines}
-            centileStroke={centileStyle.stroke}
-            centileStrokeWidth={centileStyle.strokeWidth}
-            axisStroke={axisStyle.stroke}
-            axisLabelFont={axisStyle.labelFont}
-            axisLabelColour={axisStyle.labelColour}
-            measurementFill={measurementStyle.fill}
-            measurementSize={measurementStyle.size}
-            measurementShape={measurementStyle.shape}
-      />
-    )
-    return Chart
+      
+      const Chart = (
+        <ChartData
+              key={measurementMethod + "-" + this.state.reference}
+              reference={this.state.reference} //the choices are ["uk-who", "turner", "trisomy-21"] REQUIRED
+              sex={this.state.sex} //the choices are ["male", "female"] REQUIRED
+              measurementMethod={measurementMethod} //the choices are ["height", "weight", "ofc", "bmi"] REQUIRED
+              measurementsArray = {measurementsArray}  // an array of Measurement class objects from dGC Optional
+              // measurementsSDSArray = {[]} // an array of SDS measurements for SDS charts Optional: currently not implemented: pass []
+              chartStyle={chartStyle}
+              axisStyle={axisStyle}
+              gridlineStyle={gridlineStyle}
+              centileStyle={centileStyle}
+              measurementStyle={measurementStyle}
+        />
+      )
+      return Chart
   }
 
   handleChangeTheme(event, {value}){
@@ -287,6 +278,7 @@ class MeasurementSegment extends Component {
     if (value==="monochrome"){
       selectedTheme=RCPCHThemeMonochrome
     }
+
     this.returnNewChart(
       this.state.measurementMethod, 
       this.state.measurementsArray, 
@@ -339,11 +331,6 @@ class MeasurementSegment extends Component {
         return
     }
   }
-
-test(param){
-  console.log(param);
-  return param
-}
 
   render(){
 
@@ -416,7 +403,7 @@ test(param){
     const TabPanes = () => <Tab menu={{ attached: 'top' }} panes={panes} activeIndex={activeIndex}
     onTabChange={this.handleTabChange}/>
 
-    const themeOptions = [{ key: 'trad', value: 'trad', text: 'Traditional' },{ key: 'tanner1', value: 'tanner1', text: 'Tanner 1' }, { key: 'tanner2', value: 'tanner2', text: 'Tanner 2' }, { key: 'tanner3', value: 'tanner3', text: 'Tanner 3' }, { key: 'tanner4', value: 'tanner4', text: 'Monochrome' }]
+    const themeOptions = [{ key: 'trad', value: 'trad', text: 'Traditional' },{ key: 'tanner1', value: 'tanner1', text: 'Tanner 1' }, { key: 'tanner2', value: 'tanner2', text: 'Tanner 2' }, { key: 'tanner3', value: 'tanner3', text: 'Tanner 3' }, { key: 'monochrome', value: 'monochrome', text: 'Monochrome' }]
 
     const ThemeSelection = () => (
       <Menu compact className="selectUpperMargin">

--- a/src/components/MeasurementSegment.js
+++ b/src/components/MeasurementSegment.js
@@ -1,12 +1,19 @@
 // React
 import React from "react";
 import { Component } from "react";
+import RCPCHTheme1 from "../components/chartThemes/rcpchTheme1";
+import RCPCHTheme2 from "../components/chartThemes/rcpchTheme2";
+import RCPCHTheme3 from "../components/chartThemes/rcpchTheme3";
+import RCPCHMonochrome  from "./chartThemes/rcpchThemeMonochrome";
+import RCPCHThemeTraditionalBoy from '../components/chartThemes/RCPCHThemeTraditionalBoy'
+import RCPCHThemeTraditionalGirl from '../components/chartThemes/RCPCHThemeTraditionalGirl'
 
 // Semantic UI React
 import { Grid, Segment, Message, Flag, Tab, Menu, Dropdown, Button, Table, List } from "semantic-ui-react";
 import ChartData from '../api/Chart'
 import MeasurementForm from "../components/MeasurementForm";
 import '../index.css'
+import RCPCHThemeMonochrome from "./chartThemes/rcpchThemeMonochrome";
 
 /*
     return object structure from API
@@ -53,22 +60,22 @@ class MeasurementSegment extends Component {
         super(props)
 
         // const dummyData=[{birth_data:{birth_date:"Wed, 28 Jan 2015 00:00:00 GMT",estimated_date_delivery:null,estimated_date_delivery_string:null,gestation_days:0,gestation_weeks:40,sex:"male"},child_observation_value:{measurement_method:"height",observation_value:110},measurement_calculated_values:{centile:13,centile_band:"This height measurement is between the 9th and 25th centiles.",measurement_method:"height",sds:-1.117076305831875},measurement_dates:{chronological_calendar_age:"5 years, 10 months and 4 weeks",chronological_decimal_age:5.9110198494182065,clinician_decimal_age_comment:"Born Term. No correction necessary.",corrected_calendar_age:null,corrected_decimal_age:5.9110198494182065,corrected_gestational_age:{corrected_gestation_days:null,corrected_gestation_weeks:null},lay_decimal_age_comment:"At 40+0, your child is considered to have been born at term. No age adjustment is necessary.",observation_date:"Sat, 26 Dec 2020 00:00:00 GMT"}}]
+        const defaultTheme = RCPCHMonochrome;
         
         this.state = {
           measurementMethod: "height",
           reference: "uk-who",
           sex: "male",
-          chartStyle: this.returnChartStyle('#ffffff'),
-          axisStyle: this.returnAxisStyle("#000000", 'sans', '#000000'),
-          centileStyle: this.returnCentileStyle("#000000", 0.5),
-          gridlines: false,
-          gridlineStyle: this.returnGridlineStyle(0.25, "#D9D9D9", false),
-          measurementStyle: this.returnMeasurementStyle("#000000", "1", "circle"),
+          chartStyle: defaultTheme.chart,
+          axisStyle: defaultTheme.axes,
+          centileStyle: defaultTheme.centiles,
+          gridlineStyle: defaultTheme.gridlines,
+          measurementStyle: defaultTheme.measurements,
           heights: [],
           weights: [],
           ofcs: [],
           bmis: [],
-          theme: 'simple',
+          theme: 'tanner4',
           activeIndex: 0, //set tab to height
           flip: false, // flag to determine if results or chart showing
           heightDisabled: false,
@@ -120,7 +127,6 @@ class MeasurementSegment extends Component {
       [],
       this.state.chartStyle,
       this.state.axisStyle,
-      this.state.gridlines,
       this.state.gridlineStyle,
       this.state.centileStyle,
       this.state.measurementStyle
@@ -135,7 +141,6 @@ class MeasurementSegment extends Component {
        [],
        this.state.chartStyle,
        this.state.axisStyle,
-       this.state.gridlines,
        this.state.gridlineStyle,
        this.state.centileStyle,
        this.state.measurementStyle
@@ -165,7 +170,6 @@ class MeasurementSegment extends Component {
       [],
       this.state.chartStyle,
       this.state.axisStyle,
-      this.state.gridlines,
       this.state.gridlineStyle,
       this.state.centileStyle,
       this.state.measurementStyle
@@ -219,7 +223,6 @@ class MeasurementSegment extends Component {
       measurementMethod, concatenated, 
       this.state.chartStyle, 
       this.state.axisStyle, 
-      this.state.gridlines, 
       this.state.gridlineStyle, 
       this.state.centileStyle, 
       this.state.measurementStyle)
@@ -231,7 +234,6 @@ class MeasurementSegment extends Component {
     measurementsArray, 
     chartStyle, 
     axisStyle, 
-    gridlines, 
     gridlineStyle, 
     centileStyle, 
     measurementStyle){
@@ -248,7 +250,7 @@ class MeasurementSegment extends Component {
             gridlineStroke={gridlineStyle.stroke}
             gridlineStrokeWidth={gridlineStyle.strokeWidth}
             gridlineDashed={gridlineStyle.dashed}
-            gridlines={gridlines}
+            gridlines={gridlineStyle.gridlines}
             centileStroke={centileStyle.stroke}
             centileStrokeWidth={centileStyle.strokeWidth}
             axisStroke={axisStyle.stroke}
@@ -262,122 +264,42 @@ class MeasurementSegment extends Component {
     return Chart
   }
 
-  returnCentileStyle(stroke, strokeWidth){
-    const centileStyle = {
-      stroke: stroke,
-      strokeWidth: strokeWidth
-    }
-    return centileStyle
-  }
-
-  returnGridlineStyle(strokeWidth, stroke, dashed){
-    const gridlineStyle = {
-      strokeWidth: strokeWidth,
-      stroke: stroke,
-      dashed: dashed
-    }
-    return gridlineStyle
-  }
-
-  returnMeasurementStyle(fill, size, shape){
-    const measurementStyle = {
-      fill: fill,
-      size: size,
-      shape: shape
-    }
-    return measurementStyle
-  }
-
-  returnAxisStyle(stroke, labelFont, labelColour){
-    let axisStyle = {
-      stroke: stroke,
-      labelFont: labelFont,
-      labelColour: labelColour
-    }
-    return axisStyle
-  }
-
-  returnChartStyle(backgroundColour){
-      const chartStyle = {
-        backgroundColour: backgroundColour
-      }
-      return chartStyle
-  }
-
   handleChangeTheme(event, {value}){
 
-    // These are the colours from the orginal paper charts now deprecated
-        // const girl = 'rgba(217, 49, 155, 1.0)';
-        // const boy = 'rgba(0, 126, 198, 1.0)';
-
-    let axisStyle
-    let measurementStyle 
-    let gridlineStyle 
-    let chartStyle
-    let centileStyle
-    let gridlines
-
+    let selectedTheme;
     
-    if (value === 'trad'){
-          // girl 201 85 157 - #c9559d
-          // boy 0 163 222 - #00a3de
+    if (value === 'trad'){  
       if (this.state.sex === 'male'){
-        axisStyle = this.returnAxisStyle("#D9D9D9", 'sans', '#D9D9D9')
-        centileStyle = this.returnCentileStyle("#00a3de", 0.5)
-        gridlines = true
-        gridlineStyle = this.returnGridlineStyle(0.25, "#ECECEC")
-        measurementStyle = this.returnMeasurementStyle("#000000", "1", "circle")
-        chartStyle = this.returnChartStyle('#FFFFFF')
-        
+        selectedTheme = RCPCHThemeTraditionalBoy
       } else {
-        axisStyle = this.returnAxisStyle("#D9D9D9", 'sans', '#D9D9D9')
-        centileStyle = this.returnCentileStyle("#c9559d", 0.5)
-        gridlines = true
-        gridlineStyle = this.returnGridlineStyle(0.25, "#ECECEC")
-        measurementStyle = this.returnMeasurementStyle("#000000", "1", "circle")
-        chartStyle = this.returnChartStyle('#ffffff')
+        selectedTheme = RCPCHThemeTraditionalGirl
       }
     }
-    if (value === "colour"){
-      if (this.state.sex === 'male'){
-        axisStyle = this.returnAxisStyle("#cbe896", 'sans', '#504746')
-        centileStyle = this.returnCentileStyle("#ff7f11", 0.5)
-        gridlines = true
-        gridlineStyle = this.returnGridlineStyle(0.25, "#beb7a4")
-        measurementStyle = this.returnMeasurementStyle("#cbe896", "1", "circle")
-        chartStyle = this.returnChartStyle('#eaf2e3')
-      } else {
-        axisStyle = this.returnAxisStyle("#cbe896", 'sans', '#504746')
-        centileStyle = this.returnCentileStyle("#ff1b1c", 0.5)
-        gridlines = true
-        gridlineStyle = this.returnGridlineStyle(0.25, "#beb7a4")
-        measurementStyle = this.returnMeasurementStyle("#cbe896", "1", "circle")
-        chartStyle = this.returnChartStyle('#eaf2e3')
-      }
+    if (value === "tanner1"){
+      selectedTheme=RCPCHTheme1
     }
-    if (value === 'simple'){
-      axisStyle = this.returnAxisStyle("#000000", 'sans', '#000000')
-      centileStyle = this.returnCentileStyle("#000000", 0.5)
-      gridlines = false
-      gridlineStyle = this.returnGridlineStyle(0.25, "#D9D9D9", false)
-      measurementStyle = this.returnMeasurementStyle("#000000", "1", "circle")
-      chartStyle = this.returnChartStyle('#f8f8f8')
+    if (value === 'tanner2'){
+     selectedTheme=RCPCHTheme2
+    }
+    if (value==="tanner3"){
+      selectedTheme=RCPCHTheme3
+    }
+    if (value==="monochrome"){
+      selectedTheme=RCPCHThemeMonochrome
     }
     this.returnNewChart(
       this.state.measurementMethod, 
       this.state.measurementsArray, 
-      chartStyle, 
-      axisStyle, 
-      gridlines, 
-      gridlineStyle,
-      centileStyle,
-      measurementStyle)
+      selectedTheme.chart, 
+      selectedTheme.axes,
+      selectedTheme.gridlines, 
+      selectedTheme.centiles,
+      selectedTheme.measurements)
 
-    this.setState({centileStyle: centileStyle})
-    this.setState({chartStyle: chartStyle})
-    this.setState({measurementStyle: measurementStyle})
-    this.setState({axisStyle: axisStyle})
-    this.setState({gridlines: gridlines})
+    this.setState({centileStyle: selectedTheme.centiles})
+    this.setState({chartStyle: selectedTheme.chart})
+    this.setState({measurementStyle: selectedTheme.measurements})
+    this.setState({axisStyle: selectedTheme.axes})
     this.setState({theme: value})
 
   }
@@ -449,7 +371,6 @@ test(param){
             this.state.heights, 
             this.state.chartStyle, 
             this.state.axisStyle,
-            this.state.gridlines,
             this.state.gridlineStyle,
             this.state.centileStyle,
             this.state.measurementStyle
@@ -462,7 +383,6 @@ test(param){
             this.state.weights,
             this.state.chartStyle, 
             this.state.axisStyle,
-            this.state.gridlines,
             this.state.gridlineStyle,
             this.state.centileStyle,
             this.state.measurementStyle
@@ -475,7 +395,6 @@ test(param){
             this.state.bmis,
             this.state.chartStyle, 
             this.state.axisStyle,
-            this.state.gridlines,
             this.state.gridlineStyle,
             this.state.centileStyle,
             this.state.measurementStyle
@@ -487,7 +406,6 @@ test(param){
           this.state.ofcs, 
           this.state.chartStyle, 
           this.state.axisStyle,
-          this.state.gridlines,
           this.state.gridlineStyle,
           this.state.centileStyle,
           this.state.measurementStyle
@@ -498,7 +416,7 @@ test(param){
     const TabPanes = () => <Tab menu={{ attached: 'top' }} panes={panes} activeIndex={activeIndex}
     onTabChange={this.handleTabChange}/>
 
-    const themeOptions = [{ key: 'trad', value: 'trad', text: 'Traditional' },{ key: 'colour', value: 'colour', text: 'Energy' }, { key: 'simple', value: 'simple', text: 'Simple' }]
+    const themeOptions = [{ key: 'trad', value: 'trad', text: 'Traditional' },{ key: 'tanner1', value: 'tanner1', text: 'Tanner 1' }, { key: 'tanner2', value: 'tanner2', text: 'Tanner 2' }, { key: 'tanner3', value: 'tanner3', text: 'Tanner 3' }, { key: 'tanner4', value: 'tanner4', text: 'Monochrome' }]
 
     const ThemeSelection = () => (
       <Menu compact className="selectUpperMargin">

--- a/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
@@ -20,50 +20,57 @@ font: Montserrat regular
 
 const centileColour = "#00a3de"
 const pubertyFill = "#66c8eb"
-const tooltip = "#b3b3b3"
+const tooltipBackgroundColour = "#b3b3b3"
+const tooltipTextColour = "#000000"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 6
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
+
 
 const RCPCHChart = new ChartObject(
-     backgroundColour,
-     809,
-     700,
-     tooltip
+    backgroundColour,
+    809,
+    700,
+    tooltipBackgroundColour,
+    tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+   true,
+   gridlineColour,
+   gridlineWidth,
+   false
 )
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill
+   centileColour,
+   centileWidth,
+   pubertyFill
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
-    axisLabelColour,
-    font,
-    10,
-    6
+   axisstroke,
+   axisLabelColour,
+   axisLabelFont,
+   axisLabelSize,
+   tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+   measurementsFill,
+   measurementsSize,
+   measurementsShape
 )
 
-const RCPCHThemeTraditionalBoy = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+const RCPCHThemeTraditionalBoy = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 
 export default RCPCHThemeTraditionalBoy

--- a/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
@@ -1,0 +1,69 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+RCPCH traditional: boy
+
+// boy 0 163 222 - #00a3de
+
+Data:   #00a3de - blue
+Area:   #66c8eb - blue tint 49%
+tooltip: #b3b3b3 - midgrey
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#00a3de"
+const pubertyFill = "#66c8eb"
+const tooltip = "#b3b3b3"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHThemeTraditionalBoy = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHThemeTraditionalBoy

--- a/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
@@ -20,50 +20,57 @@ font: Montserrat regular
 
 const centileColour = "#c9559d"
 const pubertyFill = "df99c4"
-const tooltip = "#b3b3b3"
+const tooltipBackgroundColour = "df99c4"
+const tooltipTextColour = "#000000"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 6
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
+
 
 const RCPCHChart = new ChartObject(
-     backgroundColour,
-     809,
-     700,
-     tooltip
+    backgroundColour,
+    809,
+    700,
+    tooltipBackgroundColour,
+    tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+   true,
+   gridlineColour,
+   gridlineWidth,
+   false
 )
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill
+   centileColour,
+   centileWidth,
+   pubertyFill
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
-    axisLabelColour,
-    font,
-    10,
-    6
+   axisstroke,
+   axisLabelColour,
+   axisLabelFont,
+   axisLabelSize,
+   tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+   measurementsFill,
+   measurementsSize,
+   measurementsShape
 )
 
-const RCPCHThemeTraditionalGirl = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+const RCPCHThemeTraditionalGirl = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 
 export default RCPCHThemeTraditionalGirl

--- a/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
@@ -1,0 +1,69 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+Traditional: girl
+
+// girl 201 85 157 - #c9559d
+
+Data:   #c9559d - pink
+Area:   df99c4 - pink tint 40%
+tooltip: #b3b3b3 - midgrey
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#c9559d"
+const pubertyFill = "df99c4"
+const tooltip = "#b3b3b3"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHThemeTraditionalGirl = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHThemeTraditionalGirl

--- a/src/components/chartThemes/rcpchTheme1.js
+++ b/src/components/chartThemes/rcpchTheme1.js
@@ -1,0 +1,67 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+Theme 1
+
+Data:  #7159aa - purple
+Area:  #c6bddd - purple (tint 40%)
+tooltip: #fdc300 - yellow
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#7159aa"
+const pubertyFill = "#c6bddd"
+const tooltip = "#fdc300"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHTheme1 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHTheme1

--- a/src/components/chartThemes/rcpchTheme1.js
+++ b/src/components/chartThemes/rcpchTheme1.js
@@ -18,21 +18,27 @@ font: Montserrat regular
 
 const centileColour = "#7159aa"
 const pubertyFill = "#c6bddd"
-const tooltip = "#fdc300"
+const tooltipBackGroundColour = "#fdc300"
+const tooltipTextColour = "#000000"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 6
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
 
 const RCPCHChart = new ChartObject(
      backgroundColour,
      809,
      700,
-     tooltip
+     tooltipBackGroundColour,
+     tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
@@ -49,19 +55,19 @@ const RCPCHCentiles = new CentilesObject(
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
+    axisstroke,
     axisLabelColour,
-    font,
-    10,
-    6
+    axisLabelFont,
+    axisLabelSize,
+    tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+    measurementsFill,
+    measurementsSize,
+    measurementsShape
 )
 
-const RCPCHTheme1 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+const RCPCHTheme1 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 
 export default RCPCHTheme1

--- a/src/components/chartThemes/rcpchTheme2.js
+++ b/src/components/chartThemes/rcpchTheme2.js
@@ -18,21 +18,27 @@ font: Montserrat regular
 
 const centileColour = "#ff8000"
 const pubertyFill = "#ffc080"
-const tooltip = "#3366cc"
+const tooltipBackGroundColour = "#3366cc"
+const tooltipTextColour = "#FFFFFF"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 6
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
 
 const RCPCHChart = new ChartObject(
      backgroundColour,
      809,
      700,
-     tooltip
+     tooltipBackGroundColour,
+     tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
@@ -49,19 +55,19 @@ const RCPCHCentiles = new CentilesObject(
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
+    axisstroke,
     axisLabelColour,
-    font,
-    10,
-    6
+    axisLabelFont,
+    axisLabelSize,
+    tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+    measurementsFill,
+    measurementsSize,
+    measurementsShape
 )
 
-const RCPCHTheme2 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+const RCPCHTheme2 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 
 export default RCPCHTheme2

--- a/src/components/chartThemes/rcpchTheme2.js
+++ b/src/components/chartThemes/rcpchTheme2.js
@@ -1,0 +1,67 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+Theme 2
+
+Data:  #ff8000 - orange
+Area:  #ffc080 - orange (tint 40%)
+tooltip: #3366cc - strong blue
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#ff8000"
+const pubertyFill = "#ffc080"
+const tooltip = "#3366cc"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHTheme2 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHTheme2

--- a/src/components/chartThemes/rcpchTheme3.js
+++ b/src/components/chartThemes/rcpchTheme3.js
@@ -1,0 +1,67 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+Theme 3
+
+Data:   #e60700 - red
+Area:   #f59c99 - red (tint 40%)
+tooltip: #fdc300 - yellow
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#e60700"
+const pubertyFill = "#f59c99"
+const tooltip = "#fdc300"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHTheme3 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHTheme3

--- a/src/components/chartThemes/rcpchTheme3.js
+++ b/src/components/chartThemes/rcpchTheme3.js
@@ -18,21 +18,27 @@ font: Montserrat regular
 
 const centileColour = "#e60700"
 const pubertyFill = "#f59c99"
-const tooltip = "#fdc300"
+const tooltipBackGroundColour = "#fdc300"
+const tooltipTextColour = "#000000"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 6
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
 
 const RCPCHChart = new ChartObject(
      backgroundColour,
      809,
      700,
-     tooltip
+     tooltipBackGroundColour,
+     tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
@@ -49,19 +55,19 @@ const RCPCHCentiles = new CentilesObject(
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
+    axisstroke,
     axisLabelColour,
-    font,
-    10,
-    6
+    axisLabelFont,
+    axisLabelSize,
+    tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+    measurementsFill,
+    measurementsSize,
+    measurementsShape
 )
 
-const RCPCHTheme3 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+const RCPCHTheme3 = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 
 export default RCPCHTheme3

--- a/src/components/chartThemes/rcpchThemeMonochrome.js
+++ b/src/components/chartThemes/rcpchThemeMonochrome.js
@@ -1,0 +1,67 @@
+import {ChartTheme, ChartObject, GridlineObject, CentilesObject, MeasurementsObject, AxesObject} from './themes'
+
+/* 
+Theme 4 - monochrome
+
+Data:   #000000 - black
+Area:   #b3b3b3 - midgrey
+tooltip: #FFFFF - white
+
+gridlines: #d9d9d9 - light grey
+text: #000000 - black
+background colour: #FFFFFF - white
+centile width: 1.5 px
+
+font: Montserrat regular
+
+*/
+
+const centileColour = "#000000"
+const pubertyFill = "#b3b3b3"
+const tooltip = "#fdc300"
+const gridlineColour = "#d9d9d9"
+const gridlineWidth = 0.25
+const backgroundColour = "#FFFFFF"
+const centileWidth = 1.5
+const font="Montserrat"
+const axisLabelColour = "#000000"
+const axisColour = "#000000"
+const measurementsColour = "#000000"
+
+const RCPCHChart = new ChartObject(
+     backgroundColour,
+     809,
+     700,
+     tooltip
+)
+
+const RCPCHGridlines = new GridlineObject(
+    true,
+    gridlineColour,
+    gridlineWidth,
+    false
+)
+
+const RCPCHCentiles = new CentilesObject(
+    centileColour,
+    centileWidth,
+    pubertyFill
+)
+
+const RCPCHAxes = new AxesObject(
+    axisColour,
+    axisLabelColour,
+    font,
+    10,
+    6
+)
+
+const RCPCHMeasurements = new MeasurementsObject(
+    measurementsColour,
+    2.5,
+    "circle"
+)
+
+const RCPCHThemeMonochrome = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
+
+export default RCPCHThemeMonochrome

--- a/src/components/chartThemes/rcpchThemeMonochrome.js
+++ b/src/components/chartThemes/rcpchThemeMonochrome.js
@@ -13,55 +13,60 @@ background colour: #FFFFFF - white
 centile width: 1.5 px
 
 font: Montserrat regular
-
+ 
 */
 
 const centileColour = "#000000"
 const pubertyFill = "#b3b3b3"
-const tooltip = "#fdc300"
+const tooltipBackgroundColour = "#b3b3b3"
+const tooltipTextColour = "#000000"
 const gridlineColour = "#d9d9d9"
 const gridlineWidth = 0.25
 const backgroundColour = "#FFFFFF"
 const centileWidth = 1.5
-const font="Montserrat"
 const axisLabelColour = "#000000"
-const axisColour = "#000000"
-const measurementsColour = "#000000"
+const axisstroke = "#000000"
+const measurementsFill = "#000000"
+const measurementsShape = 'circle'
+const measurementsSize = 2
+const axisLabelSize = 8
+const tickLabelSize = 4
+const axisLabelFont = "Montserrat"
 
 const RCPCHChart = new ChartObject(
-     backgroundColour,
-     809,
-     700,
-     tooltip
+    backgroundColour,
+    809,
+    700,
+    tooltipBackgroundColour,
+    tooltipTextColour
 )
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+   true,
+   gridlineColour,
+   gridlineWidth,
+   false
 )
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill
+   centileColour,
+   centileWidth,
+   pubertyFill
 )
 
 const RCPCHAxes = new AxesObject(
-    axisColour,
-    axisLabelColour,
-    font,
-    10,
-    6
+   axisstroke,
+   axisLabelColour,
+   axisLabelFont,
+   axisLabelSize,
+   tickLabelSize
 )
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsColour,
-    2.5,
-    "circle"
+   measurementsFill,
+   measurementsSize,
+   measurementsShape
 )
 
-const RCPCHThemeMonochrome = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHCentiles, RCPCHAxes, RCPCHMeasurements)
-
+const RCPCHThemeMonochrome = new ChartTheme(RCPCHChart, RCPCHGridlines, RCPCHAxes, RCPCHCentiles, RCPCHMeasurements)
 export default RCPCHThemeMonochrome

--- a/src/components/chartThemes/themes.js
+++ b/src/components/chartThemes/themes.js
@@ -1,0 +1,84 @@
+export class ChartTheme{
+    constructor(chart, gridlines, axes, centiles, measurements){
+        this.chart = chart
+        this.gridlines = gridlines
+        this.axes = axes
+        this.centiles = centiles
+        this.measurements = measurements
+    }
+    get chart(){
+        return this._chart
+    }
+    get gridlines(){
+        return this._gridlines
+    }
+    get axes(){
+        return this._axes
+    }
+    get centiles(){
+        return this._centiles
+    }
+    get measurements(){
+        return this._measurements
+    }
+
+    set chart(val){
+        this._chart=val
+    }
+    set gridlines(val){
+        this._gridlines=val
+    }
+    set axes(val){
+        this._axes=val
+    }
+    set centiles(val){
+        this._centiles=val
+    }
+    set measurements(val){
+        this._measurements=val
+    }
+}
+
+export class ChartObject{
+    constructor(backgroundColour, width, height, tooltipColour){
+        this.backgroundColour = backgroundColour
+        this.width = width
+        this.height = height
+        this.tooltipColour = tooltipColour
+    }
+}
+
+export class GridlineObject{
+    constructor(gridlines, stroke, strokeWidth, dashed){
+        this.gridlines=gridlines
+        this.stroke=stroke
+        this.strokeWidth = strokeWidth
+        this.dashed=dashed
+    }
+}
+
+export class AxesObject{
+    constructor(axisStroke, axisLabelColour, axisLabelFont, axisLabelSize, tickLabelSize){
+        this.axisStroke=axisStroke
+        this.axisLabelFont=axisLabelFont
+        this.axisLabelColour=axisLabelColour
+        this.axisLabelSize=axisLabelSize
+        this.tickLabelSize=tickLabelSize
+    }
+}
+
+export class CentilesObject{
+    constructor(centileStroke, centileStrokeWidth, delayedPubertyAreaFill){
+        this.centileStroke=centileStroke
+        this.centileStrokeWidth=centileStrokeWidth
+        this.delayedPubertyAreaFill=delayedPubertyAreaFill
+    }
+}
+
+export class MeasurementsObject{
+    constructor(measurementFill, measurementSize, measurementShape){
+        this.measurementFill=measurementFill        
+        this.measurementSize=measurementSize
+        this.measurementShape=measurementShape    }
+}
+

--- a/src/components/chartThemes/themes.js
+++ b/src/components/chartThemes/themes.js
@@ -40,11 +40,42 @@ export class ChartTheme{
 }
 
 export class ChartObject{
-    constructor(backgroundColour, width, height, tooltipColour){
+    constructor(backgroundColour, width, height, tooltipBackgroundColour, tooltipTextColour){
         this.backgroundColour = backgroundColour
         this.width = width
         this.height = height
-        this.tooltipColour = tooltipColour
+        this.tooltipBackgroundColour = tooltipBackgroundColour
+        this.tooltipTextColour = tooltipTextColour
+    }
+    get backgroundColour(){
+        return this._backgroundColour
+    }
+    get width(){
+        return this._width
+    }
+    get height(){
+        return this._height
+    }
+    get tooltipBackgroundColour(){
+        return this._tooltipBackgroundColour
+    }
+    get tooltipTextColour(){
+        return this._tooltipTextColour
+    }
+    set backgroundColour(val){
+        this._backgroundColour=val
+    }
+    set width(val){
+        this._width=val
+    }
+    set height(val){
+        this._height=val
+    }
+    set tooltipBackgroundColour(val){
+        this._tooltipBackgroundColour=val
+    }
+    set tooltipTextColour(val){
+        this._tooltipTextColour=val
     }
 }
 
@@ -54,6 +85,30 @@ export class GridlineObject{
         this.stroke=stroke
         this.strokeWidth = strokeWidth
         this.dashed=dashed
+    }
+    get gridlines(){
+        return this._gridlines
+    }
+    get stroke(){
+        return this._stroke
+    }
+    get strokeWidth(){
+        return this._strokeWidth
+    }
+    get dashed(){
+        return this._dashed
+    }
+    set gridlines(val){
+        this._gridlines=val
+    }
+    set stroke(val){
+        this._stroke=val
+    }
+    set strokeWidth(val){
+        this._strokeWidth=val
+    }
+    set dashed(val){
+        this._dashed=val
     }
 }
 
@@ -65,13 +120,60 @@ export class AxesObject{
         this.axisLabelSize=axisLabelSize
         this.tickLabelSize=tickLabelSize
     }
+    get axisStroke(){
+        return this._axisStroke
+    }
+    get axisLabelFont(){
+        return this._axisLabelFont
+    }
+    get axisLabelColour(){
+        return this._axisLabelColour
+    }
+    get axisLabelSize(){
+        return this._axisLabelSize
+    }
+    get tickLabelSize(){
+        return this._tickLabelSize
+    }
+    set axisStroke(val){
+        this._axisStroke=val
+    }
+    set axisLabelFont(val){
+        this._axisLabelFont=val
+    }
+    set axisLabelColour(val){
+        this._axisLabelColour=val
+    }
+    set axisLabelSize(val){
+        this._axisLabelSize=val
+    }
+    set tickLabelSize(val){
+        this._tickLabelSize=val
+    }
 }
-
 export class CentilesObject{
     constructor(centileStroke, centileStrokeWidth, delayedPubertyAreaFill){
         this.centileStroke=centileStroke
         this.centileStrokeWidth=centileStrokeWidth
         this.delayedPubertyAreaFill=delayedPubertyAreaFill
+    }
+    get centileStroke(){
+        return this._centileStroke
+    }
+    get centileStrokeWidth(){
+        return this._centileStrokeWidth
+    }
+    get delayedPubertyAreaFill(){
+        return this._delayedPubertyAreaFill
+    }
+    set centileStroke(val){
+        this._centileStroke=val
+    }
+    set centileStrokeWidth(val){
+        this._centileStrokeWidth=val
+    }
+    set delayedPubertyAreaFill(val){
+        this._delayedPubertyAreaFill=val
     }
 }
 
@@ -80,5 +182,23 @@ export class MeasurementsObject{
         this.measurementFill=measurementFill        
         this.measurementSize=measurementSize
         this.measurementShape=measurementShape    }
+    get measurementFill(){
+        return this._measurementFill
+    }
+    get measurementSize(){
+        return this._measurementSize
+    }
+    get measurementShape(){
+        return this._measurementShape
+    }
+    set measurementFill(val){
+        this._measurementFill=val
+    }
+    set measurementSize(val){
+        this._measurementSize=val
+    }
+    set measurementShape(val){
+        this._measurementShape=val
+    }
 }
 


### PR DESCRIPTION
This is a breaking change and will only work with chart package 2.0 and above
The main changes are:

1. chart props are broken into 4 groups (chartStyle, centileStyle, gridlineStyle, axesStyle, measurementStyle), to pass the styling props to the chart package. The chart package has also been refactored and is also a breaking a change.
2. The RCPCH styles provided by Kirsten (not part of this repo) have been included and can now be applied to all the references. The T21 and turner refs still need more work.
3. The font prop remains outstanding