### PR TITLE
Centile labels prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "private": false,
   "license": "MIT",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "homepage": "http://rcpch.github.io/digital-growth-charts-react-client",
   "dependencies": {
-    "@rcpch/digital-growth-charts-react-component-library": "6.1.15",
+    "@rcpch/digital-growth-charts-react-component-library": "^7.0.0",
     "axios": "^0.21.1",
     "moment": "^2.29.1",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "semantic-ui-less": "^2.4.1"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "export NODE_OPTIONS=--openssl-legacy-provider && craco start",
     "debug": "craco start --verbose",
     "build": "craco build",
     "eject": "craco eject",

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -20,12 +20,7 @@ function ChartData(props) {
         title={"Name - Hospital Number"}
         measurementsArray={props.measurementsArray} // this is the plottable child data
         midParentalHeightData={props.midParentalHeightData}
-        chartStyle={props.chartStyle}
-        measurementStyle={props.measurementStyle}
-        centileStyle={props.centileStyle}
-        sdsStyle={props?.sdsStyle}
-        gridlineStyle={props.gridlineStyle}
-        axisStyle={props.axisStyle}
+        theme={props.theme}
         enableZoom
         chartType={props.chartType}
         enableExport={true}

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -8,6 +8,12 @@ import { canvasFromSVG } from "../functions/canvasFromSVG";
 function ChartData(props) {
   const isLoading = props.isLoading;
 
+  let measurements = props.measurementsArray; // if SDS charts, the array already is in the structure { measurementMethod: [measurementsArray]}
+  if (props.chartType === "centile") {
+    // as of 7.0.0 the results now need to be presented as an object where the key is the measurement method
+    measurements = { [props.measurementMethod]: props.measurementsArray };
+  }
+
   return (
     <div>
       <Dimmer active={isLoading}>
@@ -18,7 +24,7 @@ function ChartData(props) {
         measurementMethod={props.measurementMethod}
         sex={props.sex}
         title={"Name - Hospital Number"}
-        measurementsArray={props.measurementsArray} // this is the plottable child data
+        measurements={measurements} // this is the plottable child data: NOTE IN Charts 7.0.0 this has changed
         midParentalHeightData={props.midParentalHeightData}
         theme={props.theme}
         enableZoom

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -33,6 +33,7 @@ function ChartData(props) {
         enableExport={true}
         exportChartCallback={exportChartCallback}
         clinicianFocus={props.clinicianFocus}
+        showCentileLabels={true}
       />
     </div>
   );

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -7,7 +7,6 @@ import { canvasFromSVG } from "../functions/canvasFromSVG";
 
 function ChartData(props) {
   const isLoading = props.isLoading;
-  const titles = setTitle(props);
 
   return (
     <div>
@@ -18,8 +17,7 @@ function ChartData(props) {
         reference={props.reference}
         measurementMethod={props.measurementMethod}
         sex={props.sex}
-        title={titles.title}
-        subtitle={titles.subtitle}
+        title={"Name - Hospital Number"}
         measurementsArray={props.measurementsArray} // this is the plottable child data
         midParentalHeightData={props.midParentalHeightData}
         chartStyle={props.chartStyle}
@@ -42,49 +40,6 @@ function exportChartCallback(svg) {
   canvasFromSVG(svg).then((result) => {
     addToClipboard(result);
   });
-}
-
-function setTitle(props) {
-  // set the title of the chart
-  let title = "";
-  let subTitle = "";
-  if (props.reference === "uk-who") {
-    title = "UK-WHO";
-  } else if (props.reference === "turner") {
-    title = "Turner's Syndrome";
-  } else if (props.reference === "trisomy-21") {
-    title = "Trisomy 21 (Down's Syndrome)";
-  }
-
-  let sexText = "";
-  let measurementText = "";
-  if (props.sex === "male") {
-    sexText = "Boys";
-  } else {
-    sexText = "Girls";
-  }
-
-  switch (props.measurementMethod) {
-    case "height":
-      measurementText = "Height / Length";
-      break;
-    case "weight":
-      measurementText = "Weight";
-      break;
-    case "bmi":
-      measurementText = "Body Mass Index";
-      break;
-    case "ofc":
-      measurementText = "Head Circumference";
-      break;
-    default:
-      measurementText = "";
-      break;
-  }
-
-  subTitle = measurementText + " - " + sexText;
-
-  return { subtitle: subTitle, title: title };
 }
 
 export default ChartData;

--- a/src/api/Chart.js
+++ b/src/api/Chart.js
@@ -33,7 +33,6 @@ function ChartData(props) {
         enableExport={true}
         exportChartCallback={exportChartCallback}
         clinicianFocus={props.clinicianFocus}
-        showCentileLabels={true}
       />
     </div>
   );

--- a/src/components/MeasurementSegment.js
+++ b/src/components/MeasurementSegment.js
@@ -2,12 +2,12 @@
 import { useState, useEffect, useMemo, Fragment } from "react";
 
 //themes
-import RCPCHTheme1 from "../components/chartThemes/rcpchTheme1";
-import RCPCHTheme2 from "../components/chartThemes/rcpchTheme2";
-import RCPCHTheme3 from "../components/chartThemes/rcpchTheme3";
-import RCPCHThemeMonochrome from "../components/chartThemes/rcpchThemeMonochrome";
-import RCPCHThemeTraditionalBoy from "../components/chartThemes/RCPCHThemeTraditionalBoy";
-import RCPCHThemeTraditionalGirl from "../components/chartThemes/RCPCHThemeTraditionalGirl";
+// import RCPCHTheme1 from "../components/chartThemes/rcpchTheme1";
+// import RCPCHTheme2 from "../components/chartThemes/rcpchTheme2";
+// import RCPCHTheme3 from "../components/chartThemes/rcpchTheme3";
+// import RCPCHThemeMonochrome from "../components/chartThemes/rcpchThemeMonochrome";
+// import RCPCHThemeTraditionalBoy from "../components/chartThemes/RCPCHThemeTraditionalBoy";
+// import RCPCHThemeTraditionalGirl from "../components/chartThemes/RCPCHThemeTraditionalGirl";
 
 // Semantic UI React
 import {
@@ -31,19 +31,19 @@ import FictionalChildForm from "./FictionalChildForm";
 import useRcpchApi from "../hooks/useRcpchApi";
 import useGlobalState from "../hooks/useGlobalState";
 
-const defaultTheme = RCPCHThemeMonochrome;
+// const defaultTheme = RCPCHThemeMonochrome;
 
 function MeasurementSegment() {
-  const [chartStyle, setChartSyle] = useState(defaultTheme.chart);
-  const [axisStyle, setAxisStyle] = useState(defaultTheme.axes);
-  const [centileStyle, setCentileStyle] = useState(defaultTheme.centiles);
-  const [sdsStyle, setSDSStyle] = useState(defaultTheme.sds);
+  // const [chartStyle, setChartSyle] = useState(defaultTheme.chart);
+  // const [axisStyle, setAxisStyle] = useState(defaultTheme.axes);
+  // const [centileStyle, setCentileStyle] = useState(defaultTheme.centiles);
+  // const [sdsStyle, setSDSStyle] = useState(defaultTheme.sds);
   const [centile, setCentile] = useState(true);
-  const [measurementStyle, setMeasurementStyle] = useState(
-    defaultTheme.measurements
-  );
+  // const [measurementStyle, setMeasurementStyle] = useState(
+  //   defaultTheme.measurements
+  // );
   const [theme, setTheme] = useState({
-    value: "tanner4",
+    value: "monochrome",
     text: "Monochrome",
   });
 
@@ -112,26 +112,26 @@ function MeasurementSegment() {
     }
   }, [errors, apiErrors, clearApiErrors, updateGlobalState]);
 
-  useEffect(() => {
-    let selectedTheme = RCPCHThemeMonochrome;
-    if (theme.value === "trad") {
-      selectedTheme =
-        sex === "male" ? RCPCHThemeTraditionalBoy : RCPCHThemeTraditionalGirl;
-    }
-    if (theme.value === "tanner1") {
-      selectedTheme = RCPCHTheme1;
-    }
-    if (theme.value === "tanner2") {
-      selectedTheme = RCPCHTheme2;
-    }
-    if (theme.value === "tanner3") {
-      selectedTheme = RCPCHTheme3;
-    }
-    setCentileStyle(selectedTheme.centiles);
-    setChartSyle(selectedTheme.chart);
-    setMeasurementStyle(selectedTheme.measurements);
-    setAxisStyle(selectedTheme.axes);
-  }, [sex, theme.value]);
+  // useEffect(() => {
+  //   let selectedTheme = RCPCHThemeMonochrome;
+  //   if (theme.value === "trad") {
+  //     selectedTheme =
+  //       sex === "male" ? RCPCHThemeTraditionalBoy : RCPCHThemeTraditionalGirl;
+  //   }
+  //   if (theme.value === "tanner1") {
+  //     selectedTheme = RCPCHTheme1;
+  //   }
+  //   if (theme.value === "tanner2") {
+  //     selectedTheme = RCPCHTheme2;
+  //   }
+  //   if (theme.value === "tanner3") {
+  //     selectedTheme = RCPCHTheme3;
+  //   }
+  //   setCentileStyle(selectedTheme.centiles);
+  //   setChartSyle(selectedTheme.chart);
+  //   setMeasurementStyle(selectedTheme.measurements);
+  //   setAxisStyle(selectedTheme.axes);
+  // }, [sex, theme.value]);
 
   useEffect(() => {
     if (results[reference][measurementMethod].length > 0) {
@@ -195,39 +195,11 @@ function MeasurementSegment() {
   };
 
   const handleChangeTheme = (event, { value }) => {
-    let selectedTheme;
-    let text;
+    // callback from select theme
+    // matches themeOptions by key and returns text to dropdown and value to chart for rerender in new theme
+    const selectedOption = themeOptions.find((o) => o.key === value);
+    const text = selectedOption["text"];
 
-    if (value === "trad") {
-      if (sex === "male") {
-        selectedTheme = RCPCHThemeTraditionalBoy;
-      } else {
-        selectedTheme = RCPCHThemeTraditionalGirl;
-      }
-      text = "Traditional";
-    }
-    if (value === "tanner1") {
-      selectedTheme = RCPCHTheme1;
-      text = "Tanner 1";
-    }
-    if (value === "tanner2") {
-      selectedTheme = RCPCHTheme2;
-      text = "Tanner 2";
-    }
-    if (value === "tanner3") {
-      selectedTheme = RCPCHTheme3;
-      text = "Tanner 3";
-    }
-    if (value === "monochrome") {
-      selectedTheme = RCPCHThemeMonochrome;
-      text = "Monochrome";
-    }
-
-    setCentileStyle(selectedTheme.centiles);
-    setSDSStyle(selectedTheme?.sds);
-    setChartSyle(selectedTheme.chart);
-    setMeasurementStyle(selectedTheme.measurements);
-    setAxisStyle(selectedTheme.axes);
     setTheme({ value: value, text: text });
   };
 
@@ -320,11 +292,7 @@ function MeasurementSegment() {
               measurementMethod={details.measurementName}
               measurementsArray={results[reference][details.measurementName]}
               midParentalHeightData={results[reference]["midParentalHeights"]}
-              chartStyle={chartStyle}
-              axisStyle={axisStyle}
-              gridlineStyle={defaultTheme.gridlines}
-              centileStyle={centileStyle}
-              measurementStyle={measurementStyle}
+              theme={theme.value}
               isLoading={isLoading}
               chartType="centile"
               clinicianFocus={clinician}
@@ -339,12 +307,7 @@ function MeasurementSegment() {
               measurementMethod={details.measurementName}
               measurementsArray={results[reference]}
               midParentalHeightData={results[reference]["midParentalHeights"]}
-              chartStyle={chartStyle}
-              axisStyle={axisStyle}
-              gridlineStyle={defaultTheme.gridlines}
-              centileStyle={centileStyle}
-              sdsStyle={sdsStyle}
-              measurementStyle={measurementStyle}
+              theme={theme.value}
               isLoading={isLoading}
               chartType="sds"
             />
@@ -380,7 +343,7 @@ function MeasurementSegment() {
             updateGlobalState={updateGlobalState}
             className="measurement-form"
             handleUtilitiesFormDataSubmit={utilitiesFormDataSubmit}
-            themeColour={centileStyle.centileStroke}
+            // themeColour={centileStyle.centileStroke}
           />
         </Tab.Pane>
       ),
@@ -537,7 +500,7 @@ const panesBlueprint = [
 
 const themeOptions = [
   { key: "monochrome", value: "monochrome", text: "Monochrome" },
-  { key: "trad", value: "trad", text: "Traditional" },
+  { key: "traditional", value: "traditional", text: "Traditional" },
   { key: "tanner1", value: "tanner1", text: "Tanner 1" },
   { key: "tanner2", value: "tanner2", text: "Tanner 2" },
   { key: "tanner3", value: "tanner3", text: "Tanner 3" },

--- a/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalBoy.js
@@ -7,7 +7,6 @@ import {
   AxesObject,
   TextStyleObject,
   SDSObject,
-  PaddingObject,
 } from "./themes";
 
 /* 
@@ -53,7 +52,7 @@ const subTitleStyle = new TextStyleObject("Arial", "#000000", 14, "normal");
 const tooltipTextStyle = new TextStyleObject(
   "Montserrat",
   tooltipTextColour,
-  0.25,
+  18,
   "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
@@ -66,8 +65,6 @@ const infoBoxTextStyle = new TextStyleObject(
 const axisLabelTextStyle = new TextStyleObject("Arial", "000000", 10, "normal");
 const tickLabelTextStyle = new TextStyleObject("Arial", "000000", 8, "normal");
 
-const chartPadding = new PaddingObject(50, 50, 25, 40);
-
 const lineStrokeWidth = 1.5;
 const heightSDSStroke = "#00a3de";
 const weightSDSStroke = "#32b5e4";
@@ -76,9 +73,6 @@ const bmiSDSStroke = "#b2e3f5";
 
 const RCPCHChart = new ChartObject(
   backgroundColour,
-  700,
-  475,
-  chartPadding,
   titleStyle,
   subTitleStyle,
   tooltipBackgroundColour,

--- a/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
+++ b/src/components/chartThemes/RCPCHThemeTraditionalGirl.js
@@ -7,7 +7,6 @@ import {
   AxesObject,
   TextStyleObject,
   SDSObject,
-  PaddingObject,
 } from "./themes";
 
 /* 
@@ -49,7 +48,7 @@ const subTitleStyle = new TextStyleObject("Arial", "#000000", 14, "normal");
 const tooltipTextStyle = new TextStyleObject(
   "Montserrat",
   tooltipTextColour,
-  0.25,
+  18,
   "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
@@ -62,8 +61,6 @@ const infoBoxTextStyle = new TextStyleObject(
 const axisLabelTextStyle = new TextStyleObject("Arial", "000000", 10, "normal");
 const tickLabelTextStyle = new TextStyleObject("Arial", "000000", 8, "normal");
 
-const chartPadding = new PaddingObject(50, 50, 25, 40);
-
 const lineStrokeWidth = 1.5;
 const heightSDSStroke = "#c9559d";
 const weightSDSStroke = "#d376b0";
@@ -72,9 +69,6 @@ const bmiSDSStroke = "#eecce1";
 
 const RCPCHChart = new ChartObject(
   backgroundColour,
-  700,
-  475,
-  chartPadding,
   titleStyle,
   subTitleStyle,
   tooltipBackgroundColour,

--- a/src/components/chartThemes/rcpchTheme1.js
+++ b/src/components/chartThemes/rcpchTheme1.js
@@ -1,14 +1,13 @@
 import {
-    ChartTheme,
-    ChartObject,
-    GridlineObject,
-    CentilesObject,
-    MeasurementsObject,
-    AxesObject,
-    TextStyleObject,
-    PaddingObject,
-    SDSObject,
-} from './themes';
+  ChartTheme,
+  ChartObject,
+  GridlineObject,
+  CentilesObject,
+  MeasurementsObject,
+  AxesObject,
+  TextStyleObject,
+  SDSObject,
+} from "./themes";
 
 /* 
 Theme 1
@@ -26,110 +25,105 @@ font: Montserrat normal
 
 */
 
-const centileColour = '#7159aa';
-const pubertyFill = '#c6bddd';
-const tooltipBackGroundColour = '#fdc300';
-const gridlineColour = '#d9d9d9';
+const centileColour = "#7159aa";
+const pubertyFill = "#c6bddd";
+const tooltipBackGroundColour = "#fdc300";
+const gridlineColour = "#d9d9d9";
 const gridlineWidth = 0.25;
-const backgroundColour = '#FFFFFF';
+const backgroundColour = "#FFFFFF";
 const centileWidth = 1.5;
-const axisstroke = '#000000';
-const measurementsFill = '#000000';
-const highlightedMeasurementFill = '#7159aa';
+const axisstroke = "#000000";
+const measurementsFill = "#000000";
+const highlightedMeasurementFill = "#7159aa";
 
-const midparentalHeightStroke = '#7159aa';
+const midparentalHeightStroke = "#7159aa";
 const midparentalHeightStrokeWidth = 3.0;
-const midparentalHeightFill = '#c6bddd';
+const midparentalHeightFill = "#c6bddd";
 
-const titleStyle = new TextStyleObject('Arial', '#000000', 14, 'bold');
-const subTitleStyle = new TextStyleObject('Arial', '#000000', 14, 'normal');
+const titleStyle = new TextStyleObject("Arial", "#000000", 14, "bold");
+const subTitleStyle = new TextStyleObject("Arial", "#000000", 14, "normal");
 
 const tooltipTextStyle = new TextStyleObject(
-    'Montserrat',
-    '#000000',
-    0.25,
-    'normal'
+  "Montserrat",
+  "#000000",
+  18,
+  "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
-    'Montserrat',
-    '#000000',
-    6,
-    'normal'
+  "Montserrat",
+  "#000000",
+  6,
+  "normal"
 );
 
-const axisLabelTextStyle = new TextStyleObject('Arial', '000000', 10, 'normal');
-const tickLabelTextStyle = new TextStyleObject('Arial', '000000', 8, 'normal');
-
-const chartPadding = new PaddingObject(50, 50, 25, 40);
+const axisLabelTextStyle = new TextStyleObject("Arial", "000000", 10, "normal");
+const tickLabelTextStyle = new TextStyleObject("Arial", "000000", 8, "normal");
 
 const lineStrokeWidth = 1.5;
-const heightSDSStroke = '#7159aa';
-const weightSDSStroke = '#ff8000';
-const ofcSDSStroke = '#e60700';
-const bmiSDSStroke = '#c2a712';
+const heightSDSStroke = "#7159aa";
+const weightSDSStroke = "#ff8000";
+const ofcSDSStroke = "#e60700";
+const bmiSDSStroke = "#c2a712";
 
 const RCPCHChart = new ChartObject(
-    backgroundColour,
-    700,
-    475,
-    chartPadding,
-    titleStyle,
-    subTitleStyle,
-    tooltipBackGroundColour,
-    tooltipBackGroundColour,
-    tooltipTextStyle,
-    '#CDCDCD',
-    '#CDCDCD',
-    '#CDCDCD',
-    '#CDCDCD',
-    infoBoxTextStyle,
-    '#c6bddd',
-    '#7159aa',
-    '#FFFFFF'
+  backgroundColour,
+  titleStyle,
+  subTitleStyle,
+  tooltipBackGroundColour,
+  tooltipBackGroundColour,
+  tooltipTextStyle,
+  "#CDCDCD",
+  "#CDCDCD",
+  "#CDCDCD",
+  "#CDCDCD",
+  infoBoxTextStyle,
+  "#c6bddd",
+  "#7159aa",
+  "#FFFFFF"
 );
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+  true,
+  gridlineColour,
+  gridlineWidth,
+  false
 );
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill,
-    midparentalHeightStroke,
-    midparentalHeightStrokeWidth,
-    midparentalHeightFill
+  centileColour,
+  centileWidth,
+  pubertyFill,
+  midparentalHeightStroke,
+  midparentalHeightStrokeWidth,
+  midparentalHeightFill
 );
 
 const RCPCHSDS = new SDSObject(
-    lineStrokeWidth,
-    heightSDSStroke,
-    weightSDSStroke,
-    ofcSDSStroke,
-    bmiSDSStroke
+  lineStrokeWidth,
+  heightSDSStroke,
+  weightSDSStroke,
+  ofcSDSStroke,
+  bmiSDSStroke
 );
 
 const RCPCHAxes = new AxesObject(
-    axisstroke,
-    axisLabelTextStyle,
-    tickLabelTextStyle
+  axisstroke,
+  axisLabelTextStyle,
+  tickLabelTextStyle
 );
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsFill,
-    highlightedMeasurementFill
+  measurementsFill,
+  highlightedMeasurementFill
 );
 
 const RCPCHTheme1 = new ChartTheme(
-    RCPCHChart,
-    RCPCHGridlines,
-    RCPCHAxes,
-    RCPCHCentiles,
-    RCPCHSDS,
-    RCPCHMeasurements
+  RCPCHChart,
+  RCPCHGridlines,
+  RCPCHAxes,
+  RCPCHCentiles,
+  RCPCHSDS,
+  RCPCHMeasurements
 );
 
 export default RCPCHTheme1;

--- a/src/components/chartThemes/rcpchTheme2.js
+++ b/src/components/chartThemes/rcpchTheme2.js
@@ -1,14 +1,13 @@
 import {
-    ChartTheme,
-    ChartObject,
-    GridlineObject,
-    CentilesObject,
-    SDSObject,
-    MeasurementsObject,
-    AxesObject,
-    TextStyleObject,
-    PaddingObject,
-} from './themes';
+  ChartTheme,
+  ChartObject,
+  GridlineObject,
+  CentilesObject,
+  SDSObject,
+  MeasurementsObject,
+  AxesObject,
+  TextStyleObject,
+} from "./themes";
 
 /* 
 Theme 2
@@ -26,110 +25,111 @@ font: Montserrat normal
 
 */
 
-const centileColour = '#ff8000';
-const pubertyFill = '#ffc080';
-const tooltipBackGroundColour = '#3366cc';
+const centileColour = "#ff8000";
+const pubertyFill = "#ffc080";
+const tooltipBackGroundColour = "#3366cc";
 // const tooltipTextColour = "#FFFFFF"
-const gridlineColour = '#d9d9d9';
+const gridlineColour = "#d9d9d9";
 const gridlineWidth = 0.25;
-const backgroundColour = '#FFFFFF';
+const backgroundColour = "#FFFFFF";
 const centileWidth = 1.5;
 // const axisLabelColour = "#000000"
-const axisstroke = '#000000';
-const measurementsFill = '#000000';
-const highlightedMeasurementFill = '#ff8000'; // centile colour
-const midparentalHeightStroke = '#ff8000';
+const axisstroke = "#000000";
+const measurementsFill = "#000000";
+const highlightedMeasurementFill = "#ff8000"; // centile colour
+const midparentalHeightStroke = "#ff8000";
 const midparentalHeightStrokeWidth = 0.25;
-const midparentalHeightFill = '#ffc080';
+const midparentalHeightFill = "#ffc080";
 
-const titleStyle = new TextStyleObject('Arial', '#000000', 14, 'bold');
-const subTitleStyle = new TextStyleObject('Arial', '#000000', 14, 'normal');
+const titleStyle = new TextStyleObject("Arial", "#000000", 14, "bold");
+const subTitleStyle = new TextStyleObject("Arial", "#000000", 14, "normal");
 
 const tooltipTextStyle = new TextStyleObject(
-    'Montserrat',
-    '#FFFFFF',
-    0.25,
-    'normal'
+  "Montserrat",
+  "#FFFFFF",
+  18,
+  "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
-    'Montserrat',
-    '#000000',
-    6,
-    'normal'
+  "Montserrat",
+  "#000000",
+  6,
+  "normal"
 );
 
-const axisLabelTextStyle = new TextStyleObject('Arial', '#000000', 10, 'normal');
-const tickLabelTextStyle = new TextStyleObject('Arial', '#000000', 8, 'normal');
-const chartPadding = new PaddingObject(50, 50, 25, 40);
+const axisLabelTextStyle = new TextStyleObject(
+  "Arial",
+  "#000000",
+  10,
+  "normal"
+);
+const tickLabelTextStyle = new TextStyleObject("Arial", "#000000", 8, "normal");
 
 const lineStrokeWidth = 1.5;
-const heightSDSStroke = '#7159aa';
-const weightSDSStroke = '#ff8000';
-const ofcSDSStroke = '#e60700';
-const bmiSDSStroke = '#c2a712';
+const heightSDSStroke = "#7159aa";
+const weightSDSStroke = "#ff8000";
+const ofcSDSStroke = "#e60700";
+const bmiSDSStroke = "#c2a712";
 
 const RCPCHChart = new ChartObject(
-    backgroundColour,
-    700,
-    475,
-    chartPadding,
-    titleStyle,
-    subTitleStyle,
-    tooltipBackGroundColour,
-    tooltipBackGroundColour,
-    tooltipTextStyle,
-    '#CDCDCD',
-    '#CDCDCD',
-    tooltipBackGroundColour,
-    tooltipBackGroundColour,
-    infoBoxTextStyle,
-    '#ffc080',
-    '#ff8000',
-    '#FFFFFF'
+  backgroundColour,
+  titleStyle,
+  subTitleStyle,
+  tooltipBackGroundColour,
+  tooltipBackGroundColour,
+  tooltipTextStyle,
+  "#CDCDCD",
+  "#CDCDCD",
+  tooltipBackGroundColour,
+  tooltipBackGroundColour,
+  infoBoxTextStyle,
+  "#ffc080",
+  "#ff8000",
+  "#FFFFFF"
 );
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+  true,
+  gridlineColour,
+  gridlineWidth,
+  false
 );
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill,
-    midparentalHeightStroke,
-    midparentalHeightStrokeWidth,
-    midparentalHeightFill
+  centileColour,
+  centileWidth,
+  pubertyFill,
+  midparentalHeightStroke,
+  midparentalHeightStrokeWidth,
+  midparentalHeightFill
 );
 
 const RCPCHSDS = new SDSObject(
-    lineStrokeWidth,
-    heightSDSStroke,
-    weightSDSStroke,
-    ofcSDSStroke,
-    bmiSDSStroke
+  lineStrokeWidth,
+  heightSDSStroke,
+  weightSDSStroke,
+  ofcSDSStroke,
+  bmiSDSStroke
 );
 
 const RCPCHAxes = new AxesObject(
-    axisstroke,
-    axisLabelTextStyle,
-    tickLabelTextStyle
+  axisstroke,
+  axisLabelTextStyle,
+  tickLabelTextStyle
 );
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsFill,
-    highlightedMeasurementFill
+  measurementsFill,
+  highlightedMeasurementFill
 );
 
 const RCPCHTheme2 = new ChartTheme(
-    RCPCHChart,
-    RCPCHGridlines,
-    RCPCHAxes,
-    RCPCHCentiles,
-    RCPCHSDS,
-    RCPCHMeasurements
+  RCPCHChart,
+  RCPCHGridlines,
+  RCPCHAxes,
+  RCPCHCentiles,
+  RCPCHSDS,
+  RCPCHMeasurements
 );
 
 export default RCPCHTheme2;

--- a/src/components/chartThemes/rcpchTheme2.js
+++ b/src/components/chartThemes/rcpchTheme2.js
@@ -58,8 +58,8 @@ const infoBoxTextStyle = new TextStyleObject(
     'normal'
 );
 
-const axisLabelTextStyle = new TextStyleObject('Arial', '000000', 10, 'normal');
-const tickLabelTextStyle = new TextStyleObject('Arial', '000000', 8, 'normal');
+const axisLabelTextStyle = new TextStyleObject('Arial', '#000000', 10, 'normal');
+const tickLabelTextStyle = new TextStyleObject('Arial', '#000000', 8, 'normal');
 const chartPadding = new PaddingObject(50, 50, 25, 40);
 
 const lineStrokeWidth = 1.5;

--- a/src/components/chartThemes/rcpchTheme3.js
+++ b/src/components/chartThemes/rcpchTheme3.js
@@ -1,14 +1,13 @@
 import {
-    ChartTheme,
-    ChartObject,
-    GridlineObject,
-    CentilesObject,
-    SDSObject,
-    MeasurementsObject,
-    AxesObject,
-    TextStyleObject,
-    PaddingObject,
-} from './themes';
+  ChartTheme,
+  ChartObject,
+  GridlineObject,
+  CentilesObject,
+  SDSObject,
+  MeasurementsObject,
+  AxesObject,
+  TextStyleObject,
+} from "./themes";
 
 /* 
 Theme 3
@@ -26,124 +25,119 @@ font: Montserrat normal
 
 */
 
-const centileColour = '#e60700';
-const pubertyFill = '#f59c99';
-const tooltipBackGroundColour = '#fdc300';
-const tooltipTextColour = '#000000';
-const gridlineColour = '#d9d9d9';
+const centileColour = "#e60700";
+const pubertyFill = "#f59c99";
+const tooltipBackGroundColour = "#fdc300";
+const tooltipTextColour = "#000000";
+const gridlineColour = "#d9d9d9";
 const gridlineWidth = 0.25;
-const backgroundColour = '#FFFFFF';
+const backgroundColour = "#FFFFFF";
 const centileWidth = 1.5;
-const axisLabelColour = '#000000';
-const axisstroke = '#000000';
-const measurementsFill = '#000000';
-const highlightedMeasurementFill = '#e60700'; // centile colour
+const axisLabelColour = "#000000";
+const axisstroke = "#000000";
+const measurementsFill = "#000000";
+const highlightedMeasurementFill = "#e60700"; // centile colour
 const axisLabelSize = 10;
 const tickLabelSize = 8;
 // const axisLabelFont = "Montserrat"
-const midparentalHeightStroke = '#e60700';
+const midparentalHeightStroke = "#e60700";
 const midparentalHeightStrokeWidth = 0.25;
-const midparentalHeightFill = '#f59c99';
+const midparentalHeightFill = "#f59c99";
 
-const titleStyle = new TextStyleObject('Arial', '#000000', 14, 'bold');
-const subTitleStyle = new TextStyleObject('Arial', '#000000', 14, 'normal');
+const titleStyle = new TextStyleObject("Arial", "#000000", 14, "bold");
+const subTitleStyle = new TextStyleObject("Arial", "#000000", 14, "normal");
 
 const tooltipTextStyle = new TextStyleObject(
-    'Montserrat',
-    tooltipTextColour,
-    0.25,
-    'normal'
+  "Montserrat",
+  tooltipTextColour,
+  18,
+  "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
-    'Montserrat',
-    '#000000',
-    6,
-    'normal'
+  "Montserrat",
+  "#000000",
+  6,
+  "normal"
 );
 
 const axisLabelTextStyle = new TextStyleObject(
-    'Arial',
-    axisLabelColour,
-    axisLabelSize,
-    'normal'
+  "Arial",
+  axisLabelColour,
+  axisLabelSize,
+  "normal"
 );
 const tickLabelTextStyle = new TextStyleObject(
-    'Arial',
-    axisLabelColour,
-    tickLabelSize,
-    'normal'
+  "Arial",
+  axisLabelColour,
+  tickLabelSize,
+  "normal"
 );
 
-const chartPadding = new PaddingObject(50, 50, 25, 40);
-
 const lineStrokeWidth = 1.5;
-const heightSDSStroke = '#7159aa';
-const weightSDSStroke = '#ff8000';
-const ofcSDSStroke = '#e60700';
-const bmiSDSStroke = '#c2a712';
+const heightSDSStroke = "#7159aa";
+const weightSDSStroke = "#ff8000";
+const ofcSDSStroke = "#e60700";
+const bmiSDSStroke = "#c2a712";
 
 const RCPCHChart = new ChartObject(
-    backgroundColour,
-    700,
-    475,
-    chartPadding,
-    titleStyle,
-    subTitleStyle,
-    tooltipBackGroundColour,
-    tooltipBackGroundColour,
-    tooltipTextStyle,
-    '#CDCDCD',
-    '#CDCDCD',
-    tooltipBackGroundColour,
-    tooltipBackGroundColour,
-    infoBoxTextStyle,
-    '#f59c99',
-    '#e60700',
-    '#FFFFFF'
+  backgroundColour,
+  titleStyle,
+  subTitleStyle,
+  tooltipBackGroundColour,
+  tooltipBackGroundColour,
+  tooltipTextStyle,
+  "#CDCDCD",
+  "#CDCDCD",
+  tooltipBackGroundColour,
+  tooltipBackGroundColour,
+  infoBoxTextStyle,
+  "#f59c99",
+  "#e60700",
+  "#FFFFFF"
 );
 
 const RCPCHGridlines = new GridlineObject(
-    true,
-    gridlineColour,
-    gridlineWidth,
-    false
+  true,
+  gridlineColour,
+  gridlineWidth,
+  false
 );
 
 const RCPCHCentiles = new CentilesObject(
-    centileColour,
-    centileWidth,
-    pubertyFill,
-    midparentalHeightStroke,
-    midparentalHeightStrokeWidth,
-    midparentalHeightFill
+  centileColour,
+  centileWidth,
+  pubertyFill,
+  midparentalHeightStroke,
+  midparentalHeightStrokeWidth,
+  midparentalHeightFill
 );
 
 const RCPCHSDS = new SDSObject(
-    lineStrokeWidth,
-    heightSDSStroke,
-    weightSDSStroke,
-    ofcSDSStroke,
-    bmiSDSStroke
+  lineStrokeWidth,
+  heightSDSStroke,
+  weightSDSStroke,
+  ofcSDSStroke,
+  bmiSDSStroke
 );
 
 const RCPCHAxes = new AxesObject(
-    axisstroke,
-    axisLabelTextStyle,
-    tickLabelTextStyle
+  axisstroke,
+  axisLabelTextStyle,
+  tickLabelTextStyle
 );
 
 const RCPCHMeasurements = new MeasurementsObject(
-    measurementsFill,
-    highlightedMeasurementFill
+  measurementsFill,
+  highlightedMeasurementFill
 );
 
 const RCPCHTheme3 = new ChartTheme(
-    RCPCHChart,
-    RCPCHGridlines,
-    RCPCHAxes,
-    RCPCHCentiles,
-    RCPCHSDS,
-    RCPCHMeasurements
+  RCPCHChart,
+  RCPCHGridlines,
+  RCPCHAxes,
+  RCPCHCentiles,
+  RCPCHSDS,
+  RCPCHMeasurements
 );
 
 export default RCPCHTheme3;

--- a/src/components/chartThemes/rcpchThemeMonochrome.js
+++ b/src/components/chartThemes/rcpchThemeMonochrome.js
@@ -6,7 +6,6 @@ import {
   MeasurementsObject,
   AxesObject,
   TextStyleObject,
-  PaddingObject,
   SDSObject,
 } from "./themes";
 
@@ -47,7 +46,7 @@ const midparentalHeightFill = "#b3b3b3";
 const tooltipTextStyle = new TextStyleObject(
   "Montserrat",
   tooltipTextColour,
-  0.25,
+  18,
   "normal"
 );
 const infoBoxTextStyle = new TextStyleObject(
@@ -60,8 +59,6 @@ const infoBoxTextStyle = new TextStyleObject(
 const axisLabelTextStyle = new TextStyleObject("Arial", "000000", 10, "normal");
 const tickLabelTextStyle = new TextStyleObject("Arial", "000000", 8, "normal");
 
-const chartPadding = new PaddingObject(50, 50, 25, 40);
-
 const lineStrokeWidth = 1.5;
 const heightSDSStroke = "#000000";
 const weightSDSStroke = "#000000";
@@ -70,9 +67,6 @@ const bmiSDSStroke = "#000000";
 
 const RCPCHChart = new ChartObject(
   backgroundColour,
-  700,
-  475,
-  chartPadding,
   titleStyle,
   subTitleStyle,
   tooltipBackgroundColour,

--- a/src/components/chartThemes/themes.js
+++ b/src/components/chartThemes/themes.js
@@ -49,9 +49,6 @@ export class ChartTheme {
 export class ChartObject {
   constructor(
     backgroundColour,
-    width,
-    height,
-    padding,
     titleStyle,
     subTitleStyle,
     tooltipBackgroundColour,
@@ -67,9 +64,6 @@ export class ChartObject {
     toggleButtonTextColour
   ) {
     this.backgroundColour = backgroundColour;
-    this.width = width;
-    this.height = height;
-    this.padding = padding;
     this.titleStyle = titleStyle;
     this.subTitleStyle = subTitleStyle;
     this.tooltipBackgroundColour = tooltipBackgroundColour;
@@ -86,15 +80,6 @@ export class ChartObject {
   }
   get backgroundColour() {
     return this._backgroundColour;
-  }
-  get width() {
-    return this._width;
-  }
-  get height() {
-    return this._height;
-  }
-  get padding() {
-    return this._padding;
   }
   get titleStyle() {
     return this._titleStyle;
@@ -152,15 +137,6 @@ export class ChartObject {
   }
   set backgroundColour(val) {
     this._backgroundColour = val;
-  }
-  set width(val) {
-    this._width = val;
-  }
-  set height(val) {
-    this._height = val;
-  }
-  set padding(val) {
-    this._padding = val;
   }
   set tooltipBackgroundColour(val) {
     this._tooltipBackgroundColour = val;

--- a/src/components/chartThemes/themes.js
+++ b/src/components/chartThemes/themes.js
@@ -199,11 +199,11 @@ export class PaddingObject {
 }
 
 export class TextStyleObject {
-  constructor(name, colour, size, weight) {
+  constructor(name, colour, size, style) {
     this.name = name;
     this.colour = colour;
     this.size = size;
-    this.weight = weight;
+    this.weight = style;
   }
   get name() {
     return this._name;
@@ -226,8 +226,8 @@ export class TextStyleObject {
   set size(val) {
     this._size = val;
   }
-  set weight(val) {
-    this._weight = val;
+  set style(val) {
+    this._style = val;
   }
 }
 


### PR DESCRIPTION
The is a breaking change and bumps the major version
It only works with version 7.0.0 of the RCPCH digital growth charts react charting library.

## Props

The prop to define which chart type is rendered is: `chartType?: 'centile' | 'sds'`

Other props are:

-   `title: string;` the title of the chart : could include patient name and identifiers
-   `measurementMethod: 'height' | 'weight' | 'ofc' | 'bmi';` _must_ be one of the options provided
-   `reference: 'uk-who' | 'turner' | 'trisomy-21';` _must_ be one of the options provided
-   `sex: 'male' | 'female';` _must_ be one of the options provided
-   `measurements: { measurementMethod: Measurement[]};` array of measurements returned from RCPCH Growth API. This should not be edited or manipulated. **NOTE this has changed in v7.0.0**
-   `midParentalHeightData?: MidParentalHeightObject | undefined;` an RCPCH object returned from the RCPCH Growth API. Should not be edited or manipulated
-   `enableZoom?: boolean;` Allows the user to zoom and pan the charts if set to true. If disabled, hides the buttons associated with this.
-   `chartType?: 'centile' | 'sds';` These are addressed below
-   `enableExport?: boolean | undefined;` Cut/Paste button. Returns an SVG snapshot of the chart (without title) if set to true. If false, the buttons associated with this are hidden.
-   `exportChartCallback(svg?: any): any;` Names the function within the client to return the exported SVG to.
-   `clinicianFocus?: boolean | undefined | null;` Toggles tooltip advice between those aimed at clinicians and those more appropriate for patients/lay people.
-   `theme?: 'monochrome' | 'traditional' | 'tanner1' | 'tanner2' | 'tanner3' | 'custom'`
-   `customThemeStyles?`: discussed below

### `measurements`

**Note in v7.0.0 this prop has changed**. Formerly `measurementsArray`, the structure has changed to conform to the following structure:

```js
{
    height?: Measurement[]
    weight?: Measurment[]
    bmi?: Measurement[]
    ofc?: Measurement[]
}
```

Measurements should be passed to the component through the `measurements` prop using this structure.

This aligns the SDS and centile charts to accept the same structure. SDS and centile charts differ,
in that SDS charts multiple measurement methods on a single chart, whereas centile charts must have one instance for each measurement method.

#### Example

An array of height measurements for a girl returned from the RCPCH Growth API:

```js
<RCPCHChart
    reference={'uk-who'}
    measurementMethod={'height'}
    sex={'female'}
    title={"Arthur Scargill - 12345678A"}
    measurements={
        height: [
            {
                birth_data: {
                    ...
                },
                bone_age: {
                    ...
                },
                child_observation_value: {
                    ...
                },
                events_data: {
                    ...
                },
                measurement_calculated_values: {
                    ...
                },
                measurement_dates: {
                    ...
                },
                plottable_data: {
                    ...
                }
            },
            ...
        ]
    } // this is the plottable child data
    midParentalHeightData={[]} // this is the optional plottable midparental height data from the RCPCH API
    theme={'traditional'}
    enableZoom
    chartType={'centile'}
    enableExport={false}
    exportChartCallback={()=>{}} // this is a callback for the export chart function if true
    clinicianFocus={false}
/>
```

In the same way, an implementation for the sds charts would be:

```js
<RCPCHChart
    reference={'uk-who'}
    measurementMethod={'height'}
    sex={'female'}
    title={"Arthur Scargill - 12345678A"}
    measurements={
        height: [
            {
                birth_data: {
                    ...
                },
                bone_age: {
                    ...
                },
                child_observation_value: {
                    ...
                },
                events_data: {
                    ...
                },
                measurement_calculated_values: {
                    ...
                },
                measurement_dates: {
                    ...
                },
                plottable_data: {
                    ...
                }
            },
            ...
        ],
        weight: [
            {
                birth_data: {
                    ...
                },
                bone_age: {
                    ...
                },
                child_observation_value: {
                    ...
                },
                events_data: {
                    ...
                },
                measurement_calculated_values: {
                    ...
                },
                measurement_dates: {
                    ...
                },
                plottable_data: {
                    ...
                }
            },
            ...
        ],
        ofc: [],
        bmi: []
    } // this is the plottable child data
    midParentalHeightData={[]} // this is the optional plottable midparental height data from the RCPCH API
    theme={'traditional'}
    enableZoom
    chartType={'sds'}
    enableExport={false}
    exportChartCallback={()=>{}} // this is a callback for the export chart function if true
    clinicianFocus={false}
/>
```

For information the structure of the Measurement interface is provided here. This matches the response object from the RCPCH Growth API, therefore implementers should not need to use this interface:

```js
export interface Measurement {
    birth_data: {
        birth_date: string;
        estimated_date_delivery: string;
        estimated_date_delivery_string: string;
        gestation_weeks: number;
        gestation_days: number;
        sex: 'male' | 'female';
    };
    child_observation_value: {
        measurement_method: 'height' | 'weight' | 'bmi' | 'ofc';
        observation_value: number;
        observation_value_error?: string;
    };
    measurement_dates: {
        chronological_calendar_age: string;
        chronological_decimal_age: number;
        corrected_calendar_age: string;
        corrected_decimal_age: number;
        corrected_gestational_age?: {
            corrected_gestation_weeks?: number;
            corrected_gestation_days?: number;
        };
        comments?:{
            clinician_corrected_decimal_age_comment?: string;
            lay_corrected_decimal_age_comment?: string;
            clinician_chronological_decimal_age_comment: string;
            lay_chronological_decimal_age_comment: string;
        }
        observation_date: string;
        corrected_decimal_age_error?: string;
        chronological_decimal_age_error?: string;
    };
    measurement_calculated_values: {
        chronological_centile: number;
        chronological_centile_band: string;
        chronological_measurement_error?: string;
        chronological_sds: number;
        corrected_centile: number;
        corrected_centile_band: string;
        corrected_measurement_error?: string;
        corrected_percentage_median_bmi?: number
        chronological_percentage_median_bmi?: number
        corrected_sds: number;
    };
    plottable_data: {
        centile_data: {
            chronological_decimal_age_data: {
                age_error?: string;
                age_type: 'chronological_age' | 'corrected_age';
                calendar_age: string;
                centile_band: string;
                clinician_comment: string;
                lay_comment: string;
                observation_error?: string;
                observation_value_error?: string;
                x: number;
                y: number;
                b?: number;
                centile?: number;
                sds?: number;
                bone_age_label?: string;
                events_text?: string[];
                bone_age_type?: string;
                bone_age_sds?: number;
                bone_age_centile?: number;
            };
            corrected_decimal_age_data: {
                age_error?: string;
                age_type: 'chronological_age' | 'corrected_age';
                calendar_age: string;
                centile_band: string;
                clinician_comment: string;
                lay_comment: string;
                observation_error?: string;
                observation_value_error?: string;
                x: number;
                y: number;
                b?: number;
                centile?: number;
                sds?: number;
                bone_age_label?: string;
                events_text?: string[];
                bone_age_type?: string;
                bone_age_sds?: number;
                bone_age_centile?: number;
                corrected_gestational_age?: string;
            };
        };
        sds_data: {
            chronological_decimal_age_data: {
                age_error?: string;
                age_type: 'chronological_age' | 'corrected_age';
                calendar_age: string;
                centile_band: string;
                clinician_comment: string;
                lay_comment: string;
                observation_error?: string;
                observation_value_error?: string;
                x: number;
                y: number;
                b?: number;
                centile: number;
                sds: number;
                bone_age_label?: string;
                events_text?: string[];
                bone_age_sds?: number;
                bone_age_type?: string;
                bone_age_centile?: number;
            };
            corrected_decimal_age_data: {
                age_error?: string;
                age_type: 'chronological_age' | 'corrected_age';
                calendar_age: string;
                centile_band: string;
                clinician_comment: string;
                lay_comment: string;
                observation_error?: string;
                observation_value_error?: string;
                x: number;
                y: number;
                b?: number;
                centile: number;
                sds: number;
                bone_age_label?: string;
                bone_age_type?: string;
                events_text?: string[];
                bone_age_sds?: number;
                bone_age_centile?: number;
                corrected_gestational_age?: string;
            };
        };
    };
    bone_age: {
        bone_age?: number;
        bone_age_type?: string;
        bone_age_centile?: number;
        bone_age_sds?: number;
        bone_age_text?: string;
    };
    events_data: {
        events_text?: string[];
    };
}
```

### Themes vs Styles

Themes are collections of styles. The RCPCH have created some suggested themes:

1. Monochrome (default)
2. Traditional: this uses the preexisting pink and blue colours present on the paper charts
3. Tanner 1: Purple and yellow
4. Tanner 2: Orange and blue
5. Tanner 3: Red and yellow
6. Custom

These themes all have predefined attributes for `fontFamily`, `color`, `size`, `stroke` and `strokeWidth` for different aspects of the charts.
If these attributes are too prescriptive and users would like either to build their own theme,
or override styles within an existing theme, this can be done by passing in custom styles through the `customThemeStyles` prop.

All attributes are optional, therefore only those attributes where changes are requested need be passed in. The keys for the `customThemeStyles` object are as follows:

-   `chartStyle?: ChartStyle;`
-   `axisStyle?: AxisStyle;`
-   `gridlineStyle?: GridlineStyle;`
-   `centileStyle?: CentileStyle;`
-   `sdsStyle?: SDSStyle;`
-   `measurementStyle?: MeasurementStyle;`

The attributes of each of these are below:

#### `ChartStyle`

-   `backgroundColour?: string;` //background colour of chart
-   `titleStyle?: TextStyle `| undefined; // style of text in title: includes fontFamily, fontSize, colour, weight (regular/bold/italic)
-   `subTitleStyle?: TextStyle `| undefined; // style of text in subtitle: includes fontFamily, fontSize, colour, weight (regular/bold/italic)
-   `tooltipBackgroundColour?: string;` //background colour of tooltip
-   `tooltipStroke?: string;` //border colour of tooltip
-   `tooltipTextStyle?: TextStyle `| undefined; // tooltip text: includes fontFamily, fontSize, colour, weight (regular/bold/italic)
-   `termFill?: string;` // background colour of weight term area
-   `termStroke?: string;` // border colour of weight term area
-   `toggleButtonInactiveColour?: string;` // buttons - inactive colour
-   `toggleButtonActiveColour?: string;` // buttons - active colour
-   `toggleButtonTextStyle?: TextStyle | undefined;` // buttons text: includes fontFamily, fontSize, colour, weight (regular/bold/italic)

#### `MeasurementStyle`

-   `measurementFill?: string;` // measurement point fill colour - only apply to SDS charts
-   `highlightedMeasurementFill?: string;` // measurement point fill colour when hightlighted (SDS charts)
-   `eventTextStyle?: TextStyle;` // styles for text of events: includes fontFamily, fontSize, colour, weight (regular/bold/italic)

#### `CentileStyle`

-   `sdsStroke?: string;` // sds line colour
-   `centileStroke?: string;` // centile line colour
-   `delayedPubertyAreaFill?: string;` // delayed puberty area colour
-   `midParentalCentileStroke?: string;` // Midparental height centile line colour
-   `midParentalAreaFill?: string;` // Midparental height area colour

#### `SDSStyle`

-   `heightStroke?: string;` // sds line colour
-   `weightStroke?: string;` // sds line colour
-   `ofcStroke?: string;` // sds line colour
-   `bmiStroke?: string;` // sds line colour

#### `GridlineStyle`

-   `gridlines?: boolean;` // show or hide gridlines
-   `stroke?: string;` // gridline colour
-   `strokeWidth?: number;` // gridline width
-   `dashed?: boolean;` // dashed vs continuous gridlines

#### `AxisStyle`

-   `axisStroke?: string;` // Axis colour
-   `axisLabelTextStyle?: TextStyle | undefined;` // Axis label text: : includes fontFamily, fontSize, colour, weight (regular/bold/italic)
-   `tickLabelTextStyle?: TextStyle | undefined;` // Tick label text : includes fontFamily, fontSize, colour, weight (regular/bold/italic)

#### `TextStyle`

-   `name?: string;`
-   `colour?: string;`
-   `size?: number;`
-   `style?: 'bold' | 'italic' | 'normal';`

For example, if a user wished to override the background colour of the existing 'monochrome' theme:

```js
const customChartStyle: ChartStyle = {
  backgroundColour: "tomato"
}

const customStyles = {
  chartStyle: customChartStyle
}
```

And in the JSX:

```js
<RCPCHChart
    reference={'uk-who'}
    measurementMethod={'height'}
    sex={'female'}
    title={'Arthur Scargill - 12345678A'}
    measurements={[]} // this is the plottable child data
    midParentalHeightData={[]} // this is the optional plottable midparental height data from the RCPCH API
    theme={'monochrome'}
    customThemeStyles={customStyles} <---- override styles here
    enableZoom
    chartType={'centile'}
    enableExport={false}
    exportChartCallback={() => {}} // this is a callback for the export chart function if true
    clinicianFocus={false}
/>
```
