### PR TITLE
adds trisomy-21 AAP reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/src/hooks/useRcpchApi.js
+++ b/src/hooks/useRcpchApi.js
@@ -11,8 +11,8 @@ const fetchFromApi = async (inputParameters, reference, mode) => {
   */
   //  For this to work in development use http://127.0.0.1:8000 rather than localhost
   //
-  // const prod_url = import.meta.env.VITE_APP_GROWTH_API_BASEURL;
-  const prod_url = "http://127.0.0.1:8000";
+  const prod_url = import.meta.env.VITE_APP_GROWTH_API_BASEURL;
+  // const prod_url = "http://127.0.0.1:8000";
 
   let url = `${prod_url}/${reference}/${mode}`;
   if (mode === "mid-parental-height") {

--- a/src/hooks/useRcpchApi.js
+++ b/src/hooks/useRcpchApi.js
@@ -11,8 +11,8 @@ const fetchFromApi = async (inputParameters, reference, mode) => {
   */
   //  For this to work in development use http://127.0.0.1:8000 rather than localhost
   //
-  const prod_url = import.meta.env.VITE_APP_GROWTH_API_BASEURL;
-  // const prod_url = "http://127.0.0.1:8000";
+  // const prod_url = import.meta.env.VITE_APP_GROWTH_API_BASEURL;
+  const prod_url = "http://127.0.0.1:8000";
 
   let url = `${prod_url}/${reference}/${mode}`;
   if (mode === "mid-parental-height") {
@@ -56,6 +56,12 @@ const makeInitialState = () => {
       ofc: [],
     },
     "trisomy-21": {
+      height: [],
+      weight: [],
+      bmi: [],
+      ofc: [],
+    },
+    "trisomy-21-aap": {
       height: [],
       weight: [],
       bmi: [],

--- a/src/selectData/referenceOptions.js
+++ b/src/selectData/referenceOptions.js
@@ -1,6 +1,11 @@
 const referenceOptions = [
   { key: "uk-who", value: "uk-who", text: "UK-WHO" },
-  { key: "trisomy-21", value: "trisomy-21", text: "Down's Syndrome" },
+  { key: "trisomy-21", value: "trisomy-21", text: "Down's Syndrome (UK)" },
+  {
+    key: "trisomy-21-aap",
+    value: "trisomy-21-aap",
+    text: "Down's Syndrome (US-AAP) *testing*",
+  },
   { key: "turner", value: "turner", text: "Turner's syndrome" },
   { key: "cdc", value: "cdc", text: "CDC (US)" },
 ];


### PR DESCRIPTION
### Overview

This adds trisomy-21 AAP reference to the reference drop down and pulls the T21 AAP chart version (v7.2.0)

**NOTE** This has not been validated / tested