### PR TITLE
Who-chart-package-bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "7.0.0",
+  "version": "7.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rcpchgrowth-react",
-      "version": "7.0.0",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@rcpch/digital-growth-charts-react-component-library": "7.3.0",
+        "@rcpch/digital-growth-charts-react-component-library": "7.3.1",
         "axios": "1.7.5",
         "moment": "2.30.1",
         "react": "18.2.0",
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@rcpch/digital-growth-charts-react-component-library": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@rcpch/digital-growth-charts-react-component-library/-/digital-growth-charts-react-component-library-7.3.0.tgz",
-      "integrity": "sha512-pePpF1R4pS2Eo8JPhJJqrL+ejFhxb8sSXfUCNfwcSRWEdnF58dMA4umc5yC54dbSf+AKrpUAxtj+HEA2NV13CQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@rcpch/digital-growth-charts-react-component-library/-/digital-growth-charts-react-component-library-7.3.1.tgz",
+      "integrity": "sha512-BLhSTSCn7GJi7BXPh0CUTxPRMQt/X2DMfKfxJ+9Newdp/RuqzrXQuwQxrAE01p4fYmBeDX8KMtBHqLHnBoFn5A==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "sass": "1.70.0",
@@ -5242,10 +5242,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "private": false,
   "license": "MIT",
   "repository": {
@@ -23,7 +23,7 @@
     "semantic-ui-css": "2.5.0",
     "semantic-ui-react": "3.0.0-beta.2",
     "styled-components": "6.1.12",
-    "@rcpch/digital-growth-charts-react-component-library": "7.3.0"
+    "@rcpch/digital-growth-charts-react-component-library": "7.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",


### PR DESCRIPTION
### Overview
Fix for the WHO charts as well as the CDC charts where WHO2006 data were not actually included in the <2y for USA (although the calculations were correct). The WHO curves include the missing data to fill the gap at 5y between WHO 2006 and WHO 2007.
These changes are all made elsewhere in the python package, server and charting package but are made live here