### PR TITLE
Bump to v7.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@rcpch/digital-growth-charts-react-component-library": "7.3.8",
+        "@rcpch/digital-growth-charts-react-component-library": "7.3.9",
         "axios": "1.7.5",
         "moment": "2.30.1",
         "react": "18.2.0",
@@ -959,9 +959,9 @@
       }
     },
     "node_modules/@rcpch/digital-growth-charts-react-component-library": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@rcpch/digital-growth-charts-react-component-library/-/digital-growth-charts-react-component-library-7.3.8.tgz",
-      "integrity": "sha512-9UpH3eLB3vbEyAhPULzWp3bznaT13EoIAWCAkMHIOKEH3smL5etZxD4y3EWrQlV7qZv/iHdzqxr7Jap/HPuY6A==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@rcpch/digital-growth-charts-react-component-library/-/digital-growth-charts-react-component-library-7.3.9.tgz",
+      "integrity": "sha512-moc+rXXyTKOwrgcLDlfJ06uoaJzIZZ4sFZadgaEk7IPbYR5gX+Y+/tc5uhsbTun9UQ91MoqHSXMpk93X/giqDQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "sass": "1.70.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "semantic-ui-css": "2.5.0",
     "semantic-ui-react": "3.0.0-beta.2",
     "styled-components": "6.1.12",
-    "@rcpch/digital-growth-charts-react-component-library": "7.3.8"
+    "@rcpch/digital-growth-charts-react-component-library": "7.3.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",


### PR DESCRIPTION
https://github.com/rcpch/digital-growth-charts-react-component-library/releases/tag/v7.3.9