### PR TITLE
rebuilds vite config to serve from base path (./ for prod, / for dev), adds a cname for production, patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcpchgrowth-react",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+growth.rcpch.ac.uk

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,23 +1,16 @@
+/* eslint-env node */
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import fs from "fs";
+import { fileURLToPath } from "url";
+import process from "node:process";
 
-function getBasePath() {
-  // When deploying to GitHub pages it's served under a subdomain
-  // https://rcpch.github.io/digital-growth-charts-react-client/
-  //
-  // GITHUB_REPOSITORY is the full name: rcpch/digital-growth-charts-react-client
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-  if (process.env["GITHUB_REPOSITORY"]) {
-    const [, repoName] = process.env["GITHUB_REPOSITORY"].split("/");
-
-    if (repoName) {
-      return `/${repoName}/`;
-    }
-  }
-
-  return "/";
+function getBasePath(command) {
+  // Absolute base in dev, relative base for all builds (works for GitHub Pages and custom domains)
+  return command === "serve" ? "/" : "./";
 }
 
 // Check if we're in a local development environment with the library available
@@ -31,8 +24,8 @@ const isLocalDev =
     )
   );
 
-export default defineConfig(({ command, mode }) => ({
-  base: getBasePath(),
+export default defineConfig(({ command }) => ({
+  base: getBasePath(command),
   plugins: [react()],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
### Overview
Another attempt to overcome the relative path wrangles to serve the fonts.
Refactor to the vite config to serve differentially from ./ or / depending if production or development. Adds a CNAME to public folder.
working in development locally and vite preview (which serves from dist folder)

hoping this will not break live