### PR TITLE
chart version to 7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "cp -f \"./src/semantic-ui/theme.config\" \"./node_modules/semantic-ui-less/theme.config\" && mkdir -p ./public/themes/default/assets/fonts && cp -f ./node_modules/semantic-ui-less/themes/default/assets/fonts/* ./public/themes/default/assets/fonts && mkdir -p ./public/themes/default/assets/images && cp -f ./node_modules/semantic-ui-less/themes/default/assets/images/flags.png ./public/themes/default/assets/images/flags.png && mkdir -p ./public/fonts && cp -f ./node_modules/semantic-ui-less/themes/default/assets/fonts/* ./public/fonts"
   },
   "dependencies": {
-    "@rcpch/digital-growth-charts-react-component-library": "7.3.9",
+    "@rcpch/digital-growth-charts-react-component-library": "7.4.1",
     "moment": "2.30.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
### Overview

Bump the chart version to 7.4.1
This includes an update in storybook, we now support react 19 (but also 18)
Updates to centile labels and tooltips